### PR TITLE
Registry Mirror

### DIFF
--- a/pkg/ignition.go
+++ b/pkg/ignition.go
@@ -25,13 +25,6 @@ ExecStart=/usr/bin/containerd --config=/etc/containerd/config.toml
 `
 )
 
-var dockerRegistryMirrorSystemdDropin = types.SystemdUnitDropIn{
-	Name: "10-registry-mirror.conf",
-	Contents: `
-[Service]
-Environment="DOCKER_OPTS=--registry-mirror https://mirror.gcr.io"`,
-}
-
 // IgnitionFromOperatingSystemConfig is responsible to transpile the gardener OperatingSystemConfig to a ignition configuration.
 // This is currently done with container-linux-config-transpile v0.9.0 and creates ignition v2.2.0 compatible configuration,
 // which is used by ignition 0.32.0.
@@ -116,12 +109,6 @@ func IgnitionFromOperatingSystemConfig(ctx context.Context, c client.Client, con
 			}
 			cfg.Storage.Files = append(cfg.Storage.Files, containerdConfigFile)
 		}
-	} else {
-		registryMirrorDropIn := types.SystemdUnit{
-			Name:    "docker.service",
-			Dropins: []types.SystemdUnitDropIn{dockerRegistryMirrorSystemdDropin},
-		}
-		cfg.Systemd.Units = append(cfg.Systemd.Units, registryMirrorDropIn)
 	}
 
 	outCfg, report := types.Convert(cfg, "", nil)

--- a/pkg/ignition_test.go
+++ b/pkg/ignition_test.go
@@ -39,12 +39,6 @@ func TestIgnitionFromOperatingSystemConfig(t *testing.T) {
 							Contents: "[Unit]\nDescription=kubelet\n[Install]\nWantedBy=multi-user.target\n[Service]\nExecStart=/bin/kubelet",
 							Enable:   true,
 						},
-						{
-							Name: "docker.service",
-							Dropins: []types.SystemdUnitDropIn{
-								dockerRegistryMirrorSystemdDropin,
-							},
-						},
 					},
 				},
 			},
@@ -80,16 +74,6 @@ func TestIgnitionFromOperatingSystemConfig(t *testing.T) {
 								Inline: "testhost",
 							},
 							Mode: intPtr(0644),
-						},
-					},
-				},
-				Systemd: types.Systemd{
-					Units: []types.SystemdUnit{
-						{
-							Name: "docker.service",
-							Dropins: []types.SystemdUnitDropIn{
-								dockerRegistryMirrorSystemdDropin,
-							},
 						},
 					},
 				},

--- a/pkg/ignition_test.go
+++ b/pkg/ignition_test.go
@@ -39,6 +39,12 @@ func TestIgnitionFromOperatingSystemConfig(t *testing.T) {
 							Contents: "[Unit]\nDescription=kubelet\n[Install]\nWantedBy=multi-user.target\n[Service]\nExecStart=/bin/kubelet",
 							Enable:   true,
 						},
+						{
+							Name: "docker.service",
+							Dropins: []types.SystemdUnitDropIn{
+								dockerRegistryMirrorSystemdDropin,
+							},
+						},
 					},
 				},
 			},
@@ -74,6 +80,16 @@ func TestIgnitionFromOperatingSystemConfig(t *testing.T) {
 								Inline: "testhost",
 							},
 							Mode: intPtr(0644),
+						},
+					},
+				},
+				Systemd: types.Systemd{
+					Units: []types.SystemdUnit{
+						{
+							Name: "docker.service",
+							Dropins: []types.SystemdUnitDropIn{
+								dockerRegistryMirrorSystemdDropin,
+							},
 						},
 					},
 				},

--- a/pkg/internal/templates/cloud-init.sh.template
+++ b/pkg/internal/templates/cloud-init.sh.template
@@ -45,16 +45,12 @@ mkdir -p '{{ $unit.DropIns.Path }}'
 {{- end }}
 
 # Change existing worker to use docker registry-mirror
-DOCKER_DROPIN_FOLDER="/etc/systemd/system/docker.service.d"
-DOCKER_DROPIN_REGISTRY_MIRROR="${DOCKER_DROPIN_FOLDER}/10-registry-mirror.conf"
-mkdir -p /etc/systemd/system/docker.service.d
-if [ ! -f "${DOCKER_DROPIN_REGISTRY_MIRROR}" ]; then
-    cat << EOF > "${DOCKER_DROPIN_REGISTRY_MIRROR}"
-[Service]
-Environment="DOCKER_OPTS=--registry-mirror https://mirror.gcr.io"
-EOF
+file="/etc/docker/daemon.json"
+if [ $(jq -r 'has("registry-mirrors")' "${file}") == "false" ]; then
+    contents=$(jq -M '. += {"registry-mirrors": ["https://mirror.gcr.io"]}' ${file})
+    echo "${contents}" > ${file}
     systemctl daemon-reload
-    systemctl restart docker
+    systemctl reload docker
 fi
 
 {{ if .Bootstrap -}}

--- a/pkg/internal/templates/cloud-init.sh.template
+++ b/pkg/internal/templates/cloud-init.sh.template
@@ -44,6 +44,19 @@ mkdir -p '{{ $unit.DropIns.Path }}'
 {{- end -}}
 {{- end }}
 
+# Change existing worker to use docker registry-mirror
+DOCKER_DROPIN_FOLDER="/etc/systemd/system/docker.service.d"
+DOCKER_DROPIN_REGISTRY_MIRROR="${DOCKER_DROPIN_FOLDER}/10-registry-mirror.conf"
+mkdir -p /etc/systemd/system/docker.service.d
+if [ ! -f "${DOCKER_DROPIN_REGISTRY_MIRROR}" ]; then
+    cat << EOF > "${DOCKER_DROPIN_REGISTRY_MIRROR}"
+[Service]
+Environment="DOCKER_OPTS=--registry-mirror https://mirror.gcr.io"
+EOF
+    systemctl daemon-reload
+    systemctl restart docker
+fi
+
 {{ if .Bootstrap -}}
 META_EP=http://100.100.100.200/latest/meta-data
 PROVIDER_ID=`curl -s $META_EP/region-id`.`curl -s $META_EP/instance-id`


### PR DESCRIPTION
- use mirror.gcr.io as pull-through cache for images of the docker-hub
- workers with docker will be softly upgraded (docker daemon is reloaded)
- workers with containerd need to be reprovisioned