### PR TITLE
fix: set file permissions to 0644 for /etc/systemd/timesyncd.conf

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -244,6 +244,7 @@ NTP=%s
 					Data:     renderedContent,
 				},
 			},
+			Permissions: ptr.To(int32(0644)),
 		},
 	}
 }

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -198,7 +198,7 @@ nameserver 1.0.0.1
 						},
 					},
 					extensionsv1alpha1.File{
-						Path: "/etc/systemd/timesyncd.conf",
+						Path:        "/etc/systemd/timesyncd.conf",
 						Permissions: ptr.To(int32(420)),
 						Content: extensionsv1alpha1.FileContent{
 							Inline: &extensionsv1alpha1.FileContentInline{

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -199,6 +199,7 @@ nameserver 1.0.0.1
 					},
 					extensionsv1alpha1.File{
 						Path: "/etc/systemd/timesyncd.conf",
+						Permissions: ptr.To(int32(420)),
 						Content: extensionsv1alpha1.FileContent{
 							Inline: &extensionsv1alpha1.FileContentInline{
 								Encoding: string(extensionsv1alpha1.PlainFileCodecID),

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -199,7 +199,7 @@ nameserver 1.0.0.1
 					},
 					extensionsv1alpha1.File{
 						Path:        "/etc/systemd/timesyncd.conf",
-						Permissions: ptr.To(int32(420)),
+						Permissions: ptr.To(int32(0644)),
 						Content: extensionsv1alpha1.FileContent{
 							Inline: &extensionsv1alpha1.FileContentInline{
 								Encoding: string(extensionsv1alpha1.PlainFileCodecID),


### PR DESCRIPTION
## Description

set file permissions to 0644 for /etc/systemd/timesyncd.conf

Closes #50
