### PR TITLE
Do not deploy containerd config for systemd cgroup driver.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,5 @@
 run:
   concurrency: 4
-  deadline: 10m
 
 linters:
   disable:

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -122,6 +122,8 @@ func getExtensionFiles(osc *extensionsv1alpha1.OperatingSystemConfig, networkIso
 	}
 
 	if osc.Spec.CRIConfig != nil && osc.Spec.CRIConfig.Name == extensionsv1alpha1.CRINameContainerD {
+		// TODO: as soon as all clusters run at least 1.31 we can remove the containerd config.toml override
+		// the file will be fully managed by the GNA and latest metal-os images render the containerd default config
 		if osc.Spec.CRIConfig.CgroupDriver == nil || *osc.Spec.CRIConfig.CgroupDriver != extensionsv1alpha1.CgroupDriverSystemd {
 			extensionFiles = append(extensionFiles, extensionsv1alpha1.File{
 				Path:        "/etc/containerd/config.toml",

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -124,7 +124,7 @@ func getExtensionFiles(osc *extensionsv1alpha1.OperatingSystemConfig, networkIso
 	if osc.Spec.CRIConfig != nil && osc.Spec.CRIConfig.Name == extensionsv1alpha1.CRINameContainerD {
 		// TODO: as soon as all clusters run at least 1.31 we can remove the containerd config.toml override
 		// the file will be fully managed by the GNA and latest metal-os images render the containerd default config
-		if osc.Spec.CRIConfig.CgroupDriver == nil || *osc.Spec.CRIConfig.CgroupDriver != extensionsv1alpha1.CgroupDriverSystemd {
+		if osc.Spec.Purpose == extensionsv1alpha1.OperatingSystemConfigPurposeReconcile && (osc.Spec.CRIConfig.CgroupDriver == nil || *osc.Spec.CRIConfig.CgroupDriver != extensionsv1alpha1.CgroupDriverSystemd) {
 			extensionFiles = append(extensionFiles, extensionsv1alpha1.File{
 				Path:        "/etc/containerd/config.toml",
 				Permissions: ptr.To(int32(0644)),

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -122,7 +122,7 @@ func getExtensionFiles(osc *extensionsv1alpha1.OperatingSystemConfig, networkIso
 	}
 
 	if osc.Spec.CRIConfig != nil && osc.Spec.CRIConfig.Name == extensionsv1alpha1.CRINameContainerD {
-		if osc.Spec.CRIConfig.CgroupDriver != nil && *osc.Spec.CRIConfig.CgroupDriver != extensionsv1alpha1.CgroupDriverSystemd {
+		if osc.Spec.CRIConfig.CgroupDriver == nil || *osc.Spec.CRIConfig.CgroupDriver != extensionsv1alpha1.CgroupDriverSystemd {
 			extensionFiles = append(extensionFiles, extensionsv1alpha1.File{
 				Path:        "/etc/containerd/config.toml",
 				Permissions: ptr.To(int32(0644)),

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -162,6 +162,20 @@ disabled_plugins = []
 				}))
 			})
 
+			It("does not render containerd config when cgroup driver systemd is set", func() {
+				oscCopy := osc.DeepCopy()
+				oscCopy.Spec.CRIConfig = &extensionsv1alpha1.CRIConfig{
+					CgroupDriver: ptr.To(extensionsv1alpha1.CgroupDriverSystemd),
+				}
+
+				userData, extensionUnits, extensionFiles, err := actuator.Reconcile(ctx, log, oscCopy)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(userData).To(BeEmpty())
+				Expect(extensionUnits).To(BeNil())
+				Expect(extensionFiles).To(BeEmpty())
+			})
+
 			It("network isolation files are added", func() {
 				osc = osc.DeepCopy()
 				osc.Spec.ProviderConfig = isolatedClusterProviderConfig

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Actuator", func() {
 				userData, extensionUnits, extensionFiles, err := actuator.Reconcile(ctx, log, osc)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(string(userData)).To(ContainSubstring("/etc/containerd/config.toml"))
+				Expect(string(userData)).NotTo(ContainSubstring("/etc/containerd/config.toml"))
 				Expect(string(userData)).To(HavePrefix("{")) // check we have ignition format
 				Expect(string(userData)).To(HaveSuffix("}")) // check we have ignition format
 				Expect(extensionUnits).To(BeEmpty())
@@ -123,7 +123,7 @@ var _ = Describe("Actuator", func() {
 				userData, extensionUnits, extensionFiles, err := actuator.Reconcile(ctx, log, osc)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(string(userData)).To(ContainSubstring("/etc/containerd/config.toml"))
+				Expect(string(userData)).NotTo(ContainSubstring("/etc/containerd/config.toml"))
 				Expect(string(userData)).To(ContainSubstring("/etc/resolv.conf"))
 				Expect(string(userData)).To(HavePrefix("{")) // check we have ignition format
 				Expect(string(userData)).To(HaveSuffix("}")) // check we have ignition format


### PR DESCRIPTION
## Description

```ACTIONS_REQUIRED
Kubernetes 1.31 for worker nodes require to run on the latest OS metal-images.
``` 

Depends on: 

- https://github.com/metal-stack/metal-images/pull/282

This is the idea:

- Do not overwrite the containerd `config.toml` anymore in case systemd is configured as the cgroup driver
  - This way, the GNA can act on the default conf of containerd provided in [metal-images#282](https://github.com/metal-stack/metal-images/pull/282), such that the GNA does no longer produce a broken configuration
  - The implication is that the systemd cgroup driver requires OS images that contain this fix (in other words: K8s 1.31 can only run on new OS images)
- For old `cgroupfs` configured worker nodes the `config.toml`  will still be overwritten in order not to break them
- The PR generally removes the `config.toml` from the ignition userdata (also for old OS images). It is not required as the GNA will reconcile this file after startup.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
